### PR TITLE
fix: handle undefined "this"

### DIFF
--- a/src/app/resources/overview/overview.component.js
+++ b/src/app/resources/overview/overview.component.js
@@ -18,29 +18,32 @@ export const OverviewComponent = {
         }
 
         loadAnnouncements () {
+            let ctrl = this;
             this.networkService.getAnnouncements(false)
                 .then(function (result) {
-                    this.announcements = result.announcements;
+                    ctrl.announcements = result.announcements.sort((a, b) => (a.startDate < b.startDate ? -1 : a.startDate > b.startDate ? 1 : 0));
                 }, function (error) {
-                    this.$log.error('error in app.overview.component.loadAnnouncements', error);
+                    ctrl.$log.error('error in app.overview.component.loadAnnouncements', error);
                 });
         }
 
         loadAcbs () {
+            let ctrl = this;
             this.networkService.getAcbs(false)
                 .then(function (result) {
-                    this.acbs = result.acbs.filter(acb => !acb.retired);
+                    ctrl.acbs = result.acbs.filter(acb => !acb.retired).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
                 }, function (error) {
-                    this.$log.error('error in app.overview.component.loadAcbs', error);
+                    ctrl.$log.error('error in app.overview.component.loadAcbs', error);
                 });
         }
 
         loadAtls () {
+            let ctrl = this;
             this.networkService.getAtls(false)
                 .then(function (result) {
-                    this.atls = result.atls.filter(atl => !atl.retired);
+                    ctrl.atls = result.atls.filter(atl => !atl.retired).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
                 }, function (error) {
-                    this.$log.error('error in app.overview.component.loadAtls', error);
+                    ctrl.$log.error('error in app.overview.component.loadAtls', error);
                 });
         }
 

--- a/src/app/resources/overview/overview.component.spec.js
+++ b/src/app/resources/overview/overview.component.spec.js
@@ -5,8 +5,9 @@
         var $log, $q, ctrl, el, mock, networkService, scope;
 
         mock = {
-            acbs: [{id: 0, name: 'test-acb'}, {id: 1, name: 'retired-acb', retired: true}],
-            atls: [{id: 0, name: 'test-atl'}, {id: 1, name: 'retired-atl', retired: true}],
+            acbs: [{id: 0, name: 'test-acb', retired: false}, {id: 1, name: 'retired-acb', retired: true}],
+            atls: [{id: 0, name: 'test-atl', retired: false}, {id: 1, name: 'retired-atl', retired: true}],
+            announcements: [{title: 0, description: 'test-atl'}],
         };
 
         beforeEach(function () {
@@ -26,7 +27,7 @@
                 networkService = _networkService_;
                 networkService.getAcbs.and.returnValue($q.when({ acbs: mock.acbs }));
                 networkService.getAtls.and.returnValue($q.when({ atls: mock.atls }));
-                networkService.getAnnouncements.and.returnValue($q.when({announcements: [{title: 0, description: 'test-atl'}]}));
+                networkService.getAnnouncements.and.returnValue($q.when({announcements: mock.announcements}));
 
                 el = angular.element('<ai-overview></ai-overview>');
                 scope = $rootScope.$new();

--- a/src/app/resources/overview/overview.html
+++ b/src/app/resources/overview/overview.html
@@ -19,7 +19,7 @@
     <div class="col-md-8">
       <span ng-if="$ctrl.announcements.length > 0">
         <h2>Announcement<span ng-if="$ctrl.announcements.length > 1">s</span></h2>
-        <div ng-repeat="announcement in $ctrl.announcements | orderBy:'startDate'">
+        <div ng-repeat="announcement in $ctrl.announcements">
           <strong>{{ announcement.title }}</strong><span ng-if="announcement.text">: {{ announcement.text }}</span><br />
           Start date: {{ announcement.startDate | date : 'mediumDate' : 'UTC' }}, End date: {{ announcement.endDate | date : 'mediumDate' : 'UTC' }}
         </div>
@@ -120,13 +120,13 @@
           </tr>
         </thead>
         <tbody>
-          <tr ng-repeat="acb in $ctrl.acbs | orderBy: 'name'">
+          <tr ng-repeat="acb in $ctrl.acbs">
             <td>ONC-ACB</td>
             <td>{{ acb.name }}</td>
             <td>{{ acb.acbCode }}</td>
             <td><a ai-a ng-if="acb.website" href="{{ acb.website }}">{{ acb.website }}</a></td>
           </tr>
-          <tr ng-repeat="atl in $ctrl.atls | orderBy: 'name'">
+          <tr ng-repeat="atl in $ctrl.atls">
             <td>ONC-ATL</td>
             <td>{{ atl.name }}</td>
             <td>{{ atl.atlCode }}</td>


### PR DESCRIPTION
[#OCD-2704]

Basic problem was that "this" was undefined inside the callback that the networkService uses for doing stuff. I don't think this is the right way to do it; I think there's a way to tell the callback what "this" is supposed to be directly, but I haven't figured that out.

While debugging I ended up tweaking the spec file a little bit to move the announcements into the mock object.

Also had issues with the 'orderBy' in the html, so moved that to the controller. It doesn't have to, but Angular has removed 'orderBy' from views, moving that functionality to controllers/components, so left that change it. Could be undone if you'd like.

Tests pass, though I haven't tried loading the actual page, as I don't have tomcat running yet this morning